### PR TITLE
Only allow approves in the category for channels, not in pending-reup…

### DIFF
--- a/src/commands/tsapprove.js
+++ b/src/commands/tsapprove.js
@@ -94,8 +94,9 @@ class TSApprove extends TSCommand {
             ts.channels.modChannel || // only in shellder-bot channel
           ts.discord.messageGetChannel(message) ===
             ts.channels.pendingShellbot || // or in pending-shellbot channel
-          inCodeDiscussionChannel
-        ) // should also work in the discussion channel for that level
+          ts.discord.messageGetParent(message) ===
+            ts.channels.levelDiscussionCategory // only allow this command in the level discussion category, NOT pending re-uploads
+        )
       )
     )
       return false; // silently fail

--- a/src/commands/tsapprove.js
+++ b/src/commands/tsapprove.js
@@ -83,7 +83,6 @@ class TSApprove extends TSCommand {
     const {
       code,
       command,
-      inCodeDiscussionChannel,
     } = ts.getCodeArgument(message);
     const args = { code };
 

--- a/src/commands/tsapprove.js
+++ b/src/commands/tsapprove.js
@@ -80,10 +80,7 @@ class TSApprove extends TSCommand {
       'fix+lc',
     ];
 
-    const {
-      code,
-      command,
-    } = ts.getCodeArgument(message);
+    const { code, command } = ts.getCodeArgument(message);
     const args = { code };
 
     if (
@@ -94,8 +91,8 @@ class TSApprove extends TSCommand {
           ts.discord.messageGetChannel(message) ===
             ts.channels.pendingShellbot || // or in pending-shellbot channel
           ts.discord.messageGetParent(message) ===
-            ts.channels.levelDiscussionCategory // only allow this command in the level discussion category, NOT pending re-uploads
-        )
+            ts.channels.levelDiscussionCategory
+        ) // only allow this command in the level discussion category, NOT pending re-uploads
       )
     )
       return false; // silently fail


### PR DESCRIPTION
…loads

We have issues when approvers are putting new and/or changing their existing votes in #pending-reuploads, this should prevent those commands from being run there, forcing approvers to either use fixapprove or fixreject