### PR TITLE
Allow querying by discord_id

### DIFF
--- a/test/01 - integration/01 - command tests/WebApi.js
+++ b/test/01 - integration/01 - command tests/WebApi.js
@@ -225,6 +225,32 @@ describe('Web Apis', function () {
       assert.equal(body.levels[0].creator, 'Creator');
     });
 
+    it('POST /json, maker details by discord_id', async function () {
+      const getMember = sinon.stub(TEST.ts.discord, 'getMember');
+      getMember.returns({
+        hexColor: '#000',
+        user: {
+          avatarURL: () => {
+            return 'have';
+          },
+        },
+      });
+
+      const { body } = await TEST.request(app)
+        .post('/json')
+        .send({ url_slug: TEST.ts.url_slug, discord_id: '256' })
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      assert.notEqual(body.status, 'error');
+
+      delete body.levels[0].created_at;
+      delete body.levels[0].id;
+      assert.equal(body.levels[0].code, 'XXX-XXX-XXX');
+      assert.equal(body.levels[0].level_name, 'EZ GG');
+      assert.equal(body.levels[0].creator, 'Creator');
+    });
+
     it('POST /json, maker details no avatar', async function () {
       const getMember = sinon.stub(TEST.ts.discord, 'getMember');
       getMember.returns({


### PR DESCRIPTION
I'm wanting to use the ever-so-awesome makerteams API in combination with TGRCode's mm2 API for utility purposes with Team Jamp (detect fake clears, provide lists of levels played but not cleared via makerteams, etc.). However, all of our purposes require linking MakerTeams data to the user's discord ID, something that's not possible through the API.

A solution would be handling a new argument `discord_id` on the `/json` route exactly how the `name` argument is currently handled. I don't think this would create a security risk because discord IDs would still not be shown on data *returned* from the API- you'd have to input it specifically.

Please review my modifications carefully, because I don't really know SQL and mostly went along with the preexisting code format.